### PR TITLE
Made the title for each video segment optional.

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -111,7 +111,16 @@ def _parse_key(line):
     return key
 
 def _parse_extinf(line, data, state):
-    duration, title = line.replace(protocol.extinf + ':', '').split(',')
+    parts = line.replace(protocol.extinf + ':', '').split(',')
+
+    try:
+        duration, title = parts
+    except ValueError:
+        ## Title is optional in the HLS spec
+        ## https://tools.ietf.org/html/rfc8216#section-4.3.2.1
+        duration = parts[0]
+        title = ""
+
     state['segment'] = {'duration': float(duration), 'title': remove_quotes(title)}
 
 def _parse_ts_chunk(line, data, state):


### PR DESCRIPTION
Hi,

Thanks for writing this program. It's the best HLS analysis tool I've found.

This patch makes the title on each video segment optional.

Previously, the program was expecting to see `#EXTINF:10,'hello-i-am-a-video-segment'`. In the stream I am analyzing, it only sees `#EXTINFO:10`, and as a result it crashes.

Hope this helps.

Regards,
Glenn
